### PR TITLE
Clarifying LicenseModel change impact.

### DIFF
--- a/doc_source/aws-properties-rds-database-instance.md
+++ b/doc_source/aws-properties-rds-database-instance.md
@@ -289,7 +289,7 @@ If you specify `DBSecurityGroups`, AWS CloudFormation ignores this property\. To
 
 `LicenseModel`  <a name="cfn-rds-dbinstance-licensemodel"></a>
 The license model of the DB instance\.  
-If `DBSecurityGroups` is specified, updating the license model requires its replacement\.
+If `DBSecurityGroups` is specified, updating the license model requires a host replacement and will incur some interruptions to the database's availability\.
 *Required*: No  
 *Type*: String  
 *Update requires*: [No interruption](using-cfn-updating-stacks-update-behaviors.md#update-no-interrupt)


### PR DESCRIPTION
Documentation incorrectly indicates that changing the LicenseModel will cause a database replacement; this is not accurate. Rather, in some cases (Classic EC2 hosts) the underlying instance is replaced, and will cause some interruptions to the database. The DB::Instance itself is not replaced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
